### PR TITLE
docs: add Canada data new grad jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ For a complete list, click the following sortable link below:
 </div>
 
 ---
+
+> 🇨🇦 Looking specifically for Canada-based student roles? [Hanzilla Jobs](https://jobs.hanzilla.co/categories/data-ml/) is a free daily-updated Canadian student/recent-grad job board for data analysis, data science, AI/ML, business analytics, internships, co-ops, new-grad, junior, and entry-level roles across fields.
+
 ## Daily Job List  🌐 🧭 🏆
 
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs as a Canada-specific companion resource for data analysis/data science new-grad and student roles.
- Link directly to the data/AI/ML category so Canadian students can find daily-updated internships, co-ops, new-grad, junior, and entry-level roles across fields.

## Verification
- `git diff --check`
